### PR TITLE
WIP Correcting exception call for UnexpectedResponse

### DIFF
--- a/lib/ansible/modules/notification/snow_record.py
+++ b/lib/ansible/modules/notification/snow_record.py
@@ -269,7 +269,7 @@ def run_module():
     if state == 'present' and number is None:
         try:
             record = conn.insert(table=table, payload=dict(data))
-        except pysnow.UnexpectedResponse as e:
+        except pysnow.exceptions.UnexpectedResponseFormat as e:
             snow_error = "Failed to create record: {0}, details: {1}".format(e.error_summary, e.error_details)
             module.fail_json(msg=snow_error, **result)
         result['record'] = record
@@ -285,7 +285,7 @@ def run_module():
         except pysnow.exceptions.MultipleResults:
             snow_error = "Multiple record match"
             module.fail_json(msg=snow_error, **result)
-        except pysnow.UnexpectedResponse as e:
+        except pysnow.exceptions.UnexpectedResponseFormat as e:
             snow_error = "Failed to delete record: {0}, details: {1}".format(e.error_summary, e.error_details)
             module.fail_json(msg=snow_error, **result)
         except Exception as detail:
@@ -316,7 +316,7 @@ def run_module():
         except pysnow.exceptions.NoResults:
             snow_error = "Record does not exist"
             module.fail_json(msg=snow_error, **result)
-        except pysnow.UnexpectedResponse as e:
+        except pysnow.exceptions.UnexpectedResponseFormat as e:
             snow_error = "Failed to update record: {0}, details: {1}".format(e.error_summary, e.error_details)
             module.fail_json(msg=snow_error, **result)
         except Exception as detail:


### PR DESCRIPTION
Correcting call to pysnow.exceptions.UnexpectedFormatResponse, bad call masked true api errors.

##### SUMMARY
Resubmitting PR#41796 as it's gone stale and not maintained.

Using the snow_record.py module with an incorrect parameters will always return a generic error, or will not execute at all and fail with a generic error:

    in run_module\n except pysnow.UnexpectedResponse as e:\nAttributeError: 'module' object has no attribute 'UnexpectedResponse'\n",

This is because the pysnow python modules exception is named UnexpectedResponseFormat:

grep Unexpected /usr/lib/python2.7/site-packages/pysnow/exceptions.py
class UnexpectedResponseFormat(Exception):

Additionally, the exception call leaves out the 'exceptions' class. This code corrects these issues, and now the module will run playbooks correctly, as well as fail with the proper HTTP response codes.

Thanks to @syspimp and Robert Washington for finding the code and testing the fix.

Fixes: 41796

##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

snow_record

##### ANSIBLE VERSION
```
ansible 2.8.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/bdouglas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/bdouglas/.local/lib/python2.7/site-packages/ansible
  executable location = /home/bdouglas/.local/bin/ansible
  python version = 2.7.16 (default, Apr 30 2019, 15:54:43) [GCC 9.0.1 20190312 (Red Hat 9.0.1-0.10)]


```

##### ADDITIONAL INFORMATION

*before*

```
ansible localhost -m snow_record -a 'instance=dev62503 username=admin password=x@RTAsQ4Lj@x5vk\!*epp table=incident state=present number=INC0010006'
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'module' object has no attribute 'UnexpectedResponse'
localhost | FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/bdouglas/.ansible/tmp/ansible-tmp-1560821317.48-213892535099470/AnsiballZ_snow_record.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/home/bdouglas/.ansible/tmp/ansible-tmp-1560821317.48-213892535099470/AnsiballZ_snow_record.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/bdouglas/.ansible/tmp/ansible-tmp-1560821317.48-213892535099470/AnsiballZ_snow_record.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_snow_record_payload_Lh_5cF/__main__.py\", line 334, in <module>\n  File \"/tmp/ansible_snow_record_payload_Lh_5cF/__main__.py\", line 330, in main\n  File \"/tmp/ansible_snow_record_payload_Lh_5cF/__main__.py\", line 319, in run_module\nAttributeError: 'module' object has no attribute 'UnexpectedResponse'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}

```

*after*

```
ansible localhost -m snow_record -a 'instance=dev62503 username=admin password=**** table=incident state=present number=INC0010006'         
localhost | FAILED! => {
    "changed": false, 
    "instance": "dev62503", 
    "lookup_field": "number", 
    "msg": "Failed to update record: Unexpected HTTP GET response code. Expected 200, got 401", 
    "number": "INC0010006", 
    "table": "incident"

```